### PR TITLE
Changed function signature to avoid needlessly cloning input

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ lazy_static::lazy_static! {
 
 /// Split a string (often resulting from reading in a file) into
 /// frontmatter and content portions.
-pub fn matter(input: &str) -> Option<(String, String)> {
+pub fn matter(input: &str) -> Option<(&str, &str)> {
     let mut captures: Option<Captures> = None;
 
     if DEFAULT_EXP.is_match(input) {
@@ -34,11 +34,20 @@ pub fn matter(input: &str) -> Option<(String, String)> {
     }
 
     if let Some(cap) = captures {
-        let res = (cap[1].trim().to_string(), cap[2].trim().to_string());
-        return Some(res)
+        let res = (
+            cap.get(1)
+                .map(|m| m.as_str())
+                .unwrap_or_else(|| panic!("no group at index '1'"))
+                .trim(),
+            cap.get(2)
+                .map(|m| m.as_str())
+                .unwrap_or_else(|| panic!("no group at index '2'"))
+                .trim(),
+        );
+        Some(res)
+    } else {
+        None
     }
-
-    None
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,14 +35,8 @@ pub fn matter(input: &str) -> Option<(&str, &str)> {
 
     if let Some(cap) = captures {
         let res = (
-            cap.get(1)
-                .map(|m| m.as_str())
-                .unwrap_or_else(|| panic!("no group at index '1'"))
-                .trim(),
-            cap.get(2)
-                .map(|m| m.as_str())
-                .unwrap_or_else(|| panic!("no group at index '2'"))
-                .trim(),
+            cap.get(1).expect("no group at index '1'").as_str().trim(),
+            cap.get(2).expect("no group at index '2'").as_str().trim(),
         );
         Some(res)
     } else {


### PR DESCRIPTION
_Warning: Technically a breaking change_.

I've changed the return type from `Option<(String, String)>` to `Option<(&str, &str)>`, to avoid needlessly creating two `String`s, when it's already possible to borrow `input`.

It's essentially a carbon copy of [`impl Index for Captures`](https://docs.rs/regex/1.4.2/src/regex/re_unicode.rs.html#1021-1029). However using `Index`/`cap[i]` causes `cap` to be borrowed, which makes it impossible to return the result.
